### PR TITLE
Adds the ability to to only care about a branch

### DIFF
--- a/server.rb
+++ b/server.rb
@@ -11,8 +11,9 @@ post '/payload' do
   
   push = JSON.parse(params[:payload])
   watching = params[:watching]
+  branch = params[:branch]
 
-  if (commits = watched_changes(watching, push['commits'])).length > 0
+  if (commits = watched_changes(watching, branch, push['ref'], push['commits'])).length > 0
     notify(watching, commits)
     ids = commits.map{ |c| c['id'] }.join(', ')
     "Wow things changed in: #{ids}"
@@ -21,7 +22,12 @@ post '/payload' do
   end
 end
 
-def watched_changes(watching, commits = [])
+def watched_changes(watching, watch_branch, branch, commits = nil)
+  commits ||= []
+  if (watch_branch && !branch.end_with?(watch_branch))
+    return []
+  end
+
   commits.select do |commit|
     commit['modified'].any?{ |added| added.start_with?(watching) } 
   end


### PR DESCRIPTION
Adds the ability to care about a branch via a `&branch={name}` on the hook url.

I don't write Ruby so apologies if this doesn't follow conventions.  This is neat though and very useful to me.  FYI you can also deploy this with CapRover via a `captain-defintion` file of

```
{
 "schemaVersion" :2 ,
 "templateId": "ruby-rack/2.6.0"
}
```